### PR TITLE
fix: handle re-exports

### DIFF
--- a/__test__/case_10/children/child.ts
+++ b/__test__/case_10/children/child.ts
@@ -1,0 +1,3 @@
+export const child = () => {
+  console.log("Hello World!");
+};

--- a/__test__/case_10/children/index.ts
+++ b/__test__/case_10/children/index.ts
@@ -1,0 +1,2 @@
+export { child } from './child';
+export { niño } from './nino';

--- a/__test__/case_10/children/nino.ts
+++ b/__test__/case_10/children/nino.ts
@@ -1,0 +1,1 @@
+export const niño = () => console.log("¡Hola Mundo!");

--- a/__test__/case_10/index.spec.ts
+++ b/__test__/case_10/index.spec.ts
@@ -1,0 +1,16 @@
+import * as index from ".";
+import { parent } from "./parent";
+
+describe("index", () => {
+  beforeEach(() => {
+    jest.spyOn(index.children, "child");
+    jest.spyOn(index.children, "niño");
+  })
+
+  it("called", () => {
+    parent();
+    
+    expect(index.children.child).toHaveBeenCalled();
+    expect(index.children.niño).toHaveBeenCalled();
+  });
+});

--- a/__test__/case_10/index.ts
+++ b/__test__/case_10/index.ts
@@ -1,0 +1,2 @@
+export * as children from './children';
+export { parent } from './parent';

--- a/__test__/case_10/parent.ts
+++ b/__test__/case_10/parent.ts
@@ -1,0 +1,6 @@
+import { child, niño } from "./children";
+
+export const parent = () => {
+  child();
+  niño();
+};

--- a/__test__/case_8/child.ts
+++ b/__test__/case_8/child.ts
@@ -1,0 +1,3 @@
+export const child = () => {
+  console.log("Hello World!");
+};

--- a/__test__/case_8/index.spec.ts
+++ b/__test__/case_8/index.spec.ts
@@ -1,0 +1,16 @@
+import * as index from ".";
+import { parent } from "./parent";
+
+describe("index", () => {
+  beforeEach(() => {
+    jest.spyOn(index, "child");
+    jest.spyOn(index, "niño");
+  })
+
+  it("called", () => {
+    parent();
+    
+    expect(index.child).toHaveBeenCalled();
+    expect(index.niño).toHaveBeenCalled();
+  });
+});

--- a/__test__/case_8/index.ts
+++ b/__test__/case_8/index.ts
@@ -1,0 +1,3 @@
+export { child } from './child';
+export { niño } from './nino';
+export { parent } from './parent';

--- a/__test__/case_8/nino.ts
+++ b/__test__/case_8/nino.ts
@@ -1,0 +1,1 @@
+export const niño = () => console.log("¡Hola Mundo!");

--- a/__test__/case_8/parent.ts
+++ b/__test__/case_8/parent.ts
@@ -1,0 +1,6 @@
+import { child, niño } from ".";
+
+export const parent = () => {
+  child();
+  niño();
+};

--- a/__test__/case_9/child.ts
+++ b/__test__/case_9/child.ts
@@ -1,0 +1,3 @@
+export const hello = () => {
+  console.log("Hello World!");
+};

--- a/__test__/case_9/index.spec.ts
+++ b/__test__/case_9/index.spec.ts
@@ -1,0 +1,16 @@
+import * as index from ".";
+import { parent } from "./parent";
+
+describe("index", () => {
+  beforeEach(() => {
+    jest.spyOn(index, "child");
+    jest.spyOn(index, "niño");
+  })
+
+  it("called", () => {
+    parent();
+    
+    expect(index.child).toHaveBeenCalled();
+    expect(index.niño).toHaveBeenCalled();
+  });
+});

--- a/__test__/case_9/index.ts
+++ b/__test__/case_9/index.ts
@@ -1,0 +1,3 @@
+export { hello as child } from './child';
+export { hola as niño } from './nino';
+export { parent } from './parent';

--- a/__test__/case_9/nino.ts
+++ b/__test__/case_9/nino.ts
@@ -1,0 +1,1 @@
+export const hola = () => console.log("¡Hola Mundo!");

--- a/__test__/case_9/parent.ts
+++ b/__test__/case_9/parent.ts
@@ -1,0 +1,6 @@
+import { child, niño } from ".";
+
+export const parent = () => {
+  child();
+  niño();
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "devDependencies": {
         "@swc/core": "^1.3.8",
         "@swc/jest": "^0.2.23",
+        "@types/jest": "^29.2.6",
         "jest": "^29.0.3"
     },
     "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,11 +3,13 @@ lockfileVersion: 5.4
 specifiers:
   '@swc/core': ^1.3.8
   '@swc/jest': ^0.2.23
+  '@types/jest': ^29.2.6
   jest: ^29.0.3
 
 devDependencies:
   '@swc/core': 1.3.8
   '@swc/jest': 0.2.23_@swc+core@1.3.8
+  '@types/jest': 29.2.6
   jest: 29.0.3
 
 packages:
@@ -875,6 +877,13 @@ packages:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
+    dev: true
+
+  /@types/jest/29.2.6:
+    resolution: {integrity: sha512-XEUC/Tgw3uMh6Ho8GkUtQ2lPhY5Fmgyp3TdlkTJs1W9VgNxs+Ow/x3Elh8lHQKqCbZL0AubQuqWjHVT033Hhrw==}
+    dependencies:
+      expect: 29.0.3
+      pretty-format: 29.0.3
     dev: true
 
   /@types/node/18.11.0:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ impl VisitMut for TransformVisitor {
 
     fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
         let mut strip = LocalExportStrip::default();
+        strip.unresolved_mark = self.unresolved_mark;
+
         n.visit_mut_with(&mut strip);
 
         let LocalExportStrip {

--- a/tests/fixture/case_10/input.js
+++ b/tests/fixture/case_10/input.js
@@ -1,0 +1,2 @@
+export * as components from './components';
+export { configuration } from './configuration';

--- a/tests/fixture/case_10/output.js
+++ b/tests/fixture/case_10/output.js
@@ -1,0 +1,8 @@
+export { };
+Object.defineProperty(exports, "configuration", {
+    enumerable: true,
+    get: ()=>configuration,
+    configurable: true
+});
+export * as components from './components';
+const { configuration  } = require("./configuration");

--- a/tests/fixture/case_8/input.js
+++ b/tests/fixture/case_8/input.js
@@ -1,0 +1,2 @@
+export { Alert, Button } from "./components";
+export { useTheme } from "./theme";

--- a/tests/fixture/case_8/output.js
+++ b/tests/fixture/case_8/output.js
@@ -1,0 +1,15 @@
+export { };
+function _export(target, all) {
+    for(var name in all)Object.defineProperty(target, name, {
+        enumerable: true,
+        get: all[name],
+        configurable: true
+    });
+}
+_export(exports, {
+    Alert: ()=>Alert,
+    Button: ()=>Button,
+    useTheme: ()=>useTheme
+});
+const { Alert , Button  } = require("./components");
+const { useTheme  } = require("./theme");

--- a/tests/fixture/case_9/input.js
+++ b/tests/fixture/case_9/input.js
@@ -1,0 +1,2 @@
+export { Alert as SystemAlert } from './components';
+export { default as configuration } from './configuration';

--- a/tests/fixture/case_9/output.js
+++ b/tests/fixture/case_9/output.js
@@ -1,0 +1,14 @@
+export { };
+function _export(target, all) {
+    for(var name in all)Object.defineProperty(target, name, {
+        enumerable: true,
+        get: all[name],
+        configurable: true
+    });
+}
+_export(exports, {
+    SystemAlert: ()=>SystemAlert,
+    configuration: ()=>configuration
+});
+const { Alert: SystemAlert  } = require("./components");
+const { default: configuration  } = require("./configuration");


### PR DESCRIPTION
The intention here is to fix #18, #19, and #20.

The first issue I ran into was `export { Foo } from './foo'` not setting `configurable: true`. I think all of these issues are related to re-exports, though, so the plan is to address them all here.

<br>

> **Disclaimer:** I just went through the Rust book and **rustlings** a couple of months ago, and this is my first proper foray into Rust _and_ SWC. I will gladly accept guidance, however critical it may be 😅.
>
> #### Requisite ↯
> ![no-idea](https://user-images.githubusercontent.com/288160/213902539-2539bec7-0107-4393-aec6-4e9e3c6aa9fb.jpg)

