### PR TITLE
Handle `export { foo } from "foo"` and `export * as ns from "ns"`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,15 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debug_unreachable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
-dependencies = [
- "unreachable",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,9 +424,9 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1110,18 +1101,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1280,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.21"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ffecde9d1a937a61b4799478d598121b539eb7da6127c16af86a044017e1e5"
+checksum = "731cf66bd8e11030f056f91f9d8af77f83ec4377ff04d1670778a57d1607402a"
 dependencies = [
  "once_cell",
  "rkyv",
@@ -1295,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.8"
+version = "0.29.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251762fb5b797ece63903a9a6625af90f3c49b41d8c6ed40d0362a06de749d4f"
+checksum = "a97e491d31418cd33fea58e9f893316fc04b30e2b5d0e750c066e2ba4907ae54"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1305,9 +1296,9 @@ dependencies = [
  "atty",
  "better_scoped_tls",
  "cfg-if",
- "debug_unreachable",
  "either",
  "from_variant",
+ "new_debug_unreachable",
  "num-bigint",
  "once_cell",
  "parking_lot",
@@ -1328,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.38.8"
+version = "0.59.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eaf3ee1f222491f4c449451da780a35b9f1ff54ff73dd87053fe622576c87a5"
+checksum = "45f9e0be8aa923c30f911c2a2c64af67a55db0404957735f8e7f758b7aa9b055"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -1348,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.94.11"
+version = "0.96.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2509a573182f91de55320e6427e1ecf77a50dda3f63a0cc9e5a96bcaca53fe14"
+checksum = "a887102d5595b557261aa4bde35f3d71906fba674d4b79cd5c59b4155b12ee2d"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1366,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.127.15"
+version = "0.129.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb7f63d1b20dc149a3392cc93b2e35efcab80ab5daeba3b18be70fd4f704e18"
+checksum = "45f8f20522626a737753381bdf64ee53d568730f9f7e720d35960de97e5ff965"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1398,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.122.12"
+version = "0.124.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe933ad09ff54919b735253714415540c94c471e6296ff1cb5191070df582ca"
+checksum = "9e75888eabf1ad8a8968e3befc7cd20c10e4721254d3344285bd5c3a42f58dc1"
 dependencies = [
  "either",
  "enum_kind",
@@ -1417,25 +1408,21 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ecc467eff7ef4ec0a64919402b94da637003015d019de4d649e8efeceafd3f"
+checksum = "25198f96ef93c4bb4cc8fa13c9b22a018cf2c0c7609ee91f7abc7968ebc2e2df"
 dependencies = [
  "anyhow",
  "hex",
  "sha-1",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "testing",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.111.24"
+version = "0.116.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adaabe5d33574258937005a063aa0d514171745e265843856fdeef3194aa9bb"
+checksum = "5f5a212abba41897332f9ab3af8fe5d1a59f83d69e25eea119c27d9b53876688"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1455,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "0.114.10"
+version = "0.119.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce3b89d29ac3db86f939e45c34f3bf7c9cd44fec9130cd83c82c05e876a9f16"
+checksum = "8b128b6e3160e12b83c90c02a1876e15d91f5ed9e546b05becb8d63375abcffe"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1481,13 +1468,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.105.17"
+version = "0.107.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d551529c10d14a2fd8fb983d342a0801e4571accd86806ac03bdaaa80190b111"
+checksum = "d773cf626c8d3be468a883879cda3727a2f1ea6169ccd0b5b8eb2d7afb5f367b"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
+ "rustc-hash",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -1498,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.80.11"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ba4bec476ac4d25e48a6f777b19e8eb857a3ad453c830ef74176c8574177a1"
+checksum = "6b2ee0f4b61d6c426189d0d9da1333705ff3bc4513fb63633ca254595a700f75"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1524,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.8"
+version = "0.13.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e175dfc7554a1f1b7cc5e1918a11cb537f7574ba258f233c96a5479a683af9b"
+checksum = "8cab7b4d57a38aa721d3b64896f07198567e0d26fa15517eeddc52560f7f7ab8"
 dependencies = [
  "anyhow",
  "miette",
@@ -1558,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_macro"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4241e5cbfb7aae61603ca4d161e132012f488cf86393855c5cd5dddbbfe34382"
+checksum = "8c00caf955dfbff15974f061f8c2e8a8b9b5ce999cb601f02f3ec66253e81149"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1569,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "0.22.11"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63919ebb1746b87198a6b036b79f9b465be8327eb25ddddd23a867f1d18f2b5"
+checksum = "40bf5af63d89dd7ef4742695d1143156258debdc74af78973566c5d99c4a65c1"
 dependencies = [
  "better_scoped_tls",
  "rkyv",
@@ -1594,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f2bcb7223e185c4c7cbf5e0c1207dec6d2bfd5e72e3fb7b3e8d179747e9130"
+checksum = "470a1963cf182fdcbbac46e3a7fd2caf7329da0e568d3668202da9501c880e16"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1604,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb1f3561674d84947694d41fb6d5737d19539222779baeac1b3a071a2b29428"
+checksum = "6098b717cfd4c85f5cddec734af191dbce461c39975ed567c32ac6d0c6d61a6d"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -1618,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1662,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.8"
+version = "0.31.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1d8f85e7121e1d4f895d394b381f6c9cfb3ec15df0c2b6771bbfa96cf356f1"
+checksum = "0a9de85488135d7351345aab356bc08ae9a23ca4d1d064238aa4e8198fa613c8"
 dependencies = [
  "ansi_term",
  "difference",
@@ -1890,15 +1878,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unreachable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,12 +1914,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,21 +14,21 @@ version     = "0.1.13"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-indexmap = "1.9.1"
-serde = "1.0.145"
-swc_core = { version = "0.38.7", features = [
+indexmap = "1.9.2"
+serde = "1.0.152"
+swc_core = { version = "0.59.12", features = [
     "ecma_ast",
     "ecma_visit",
     "swc_plugin",
     "ecma_utils",
     "swc_atoms",
-    "plugin_transform",
+    "ecma_plugin_transform",
 ] }
 
 
 [dev-dependencies]
-swc_core = { version = "0.38.7", features = ["testing_transform"] }
-testing  = "0.31.8"
+swc_core = { version = "0.59.12", features = ["testing_transform"] }
+testing  = "0.31.31"
 
 [profile.release]
 strip = "debuginfo"

--- a/__test__/case_10/children/child.ts
+++ b/__test__/case_10/children/child.ts
@@ -1,0 +1,3 @@
+export const child = () => {
+  console.log("Hello World!");
+};

--- a/__test__/case_10/children/index.ts
+++ b/__test__/case_10/children/index.ts
@@ -1,0 +1,2 @@
+export { child } from './child';
+export { niño } from './nino';

--- a/__test__/case_10/children/nino.ts
+++ b/__test__/case_10/children/nino.ts
@@ -1,0 +1,1 @@
+export const niño = () => console.log("¡Hola Mundo!");

--- a/__test__/case_10/index.spec.ts
+++ b/__test__/case_10/index.spec.ts
@@ -1,0 +1,16 @@
+import * as index from ".";
+import { parent } from "./parent";
+
+describe("index", () => {
+  beforeEach(() => {
+    jest.spyOn(index.children, "child");
+    jest.spyOn(index.children, "niño");
+  })
+
+  it("called", () => {
+    parent();
+    
+    expect(index.children.child).toHaveBeenCalled();
+    expect(index.children.niño).toHaveBeenCalled();
+  });
+});

--- a/__test__/case_10/index.ts
+++ b/__test__/case_10/index.ts
@@ -1,0 +1,2 @@
+export * as children from './children';
+export { parent } from './parent';

--- a/__test__/case_10/parent.ts
+++ b/__test__/case_10/parent.ts
@@ -1,0 +1,6 @@
+import { child, niño } from "./children";
+
+export const parent = () => {
+  child();
+  niño();
+};

--- a/__test__/case_8/child.ts
+++ b/__test__/case_8/child.ts
@@ -1,0 +1,3 @@
+export const child = () => {
+  console.log("Hello World!");
+};

--- a/__test__/case_8/index.spec.ts
+++ b/__test__/case_8/index.spec.ts
@@ -1,0 +1,16 @@
+import * as index from ".";
+import { parent } from "./parent";
+
+describe("index", () => {
+  beforeEach(() => {
+    jest.spyOn(index, "child");
+    jest.spyOn(index, "niño");
+  })
+
+  it("called", () => {
+    parent();
+    
+    expect(index.child).toHaveBeenCalled();
+    expect(index.niño).toHaveBeenCalled();
+  });
+});

--- a/__test__/case_8/index.ts
+++ b/__test__/case_8/index.ts
@@ -1,0 +1,3 @@
+export { child } from './child';
+export { niño } from './nino';
+export { parent } from './parent';

--- a/__test__/case_8/nino.ts
+++ b/__test__/case_8/nino.ts
@@ -1,0 +1,1 @@
+export const niño = () => console.log("¡Hola Mundo!");

--- a/__test__/case_8/parent.ts
+++ b/__test__/case_8/parent.ts
@@ -1,0 +1,6 @@
+import { child, niño } from ".";
+
+export const parent = () => {
+  child();
+  niño();
+};

--- a/__test__/case_9/child.ts
+++ b/__test__/case_9/child.ts
@@ -1,0 +1,3 @@
+export const hello = () => {
+  console.log("Hello World!");
+};

--- a/__test__/case_9/index.spec.ts
+++ b/__test__/case_9/index.spec.ts
@@ -1,0 +1,16 @@
+import * as index from ".";
+import { parent } from "./parent";
+
+describe("index", () => {
+  beforeEach(() => {
+    jest.spyOn(index, "child");
+    jest.spyOn(index, "niño");
+  })
+
+  it("called", () => {
+    parent();
+    
+    expect(index.child).toHaveBeenCalled();
+    expect(index.niño).toHaveBeenCalled();
+  });
+});

--- a/__test__/case_9/index.ts
+++ b/__test__/case_9/index.ts
@@ -1,0 +1,3 @@
+export { hello as child } from './child';
+export { hola as niño } from './nino';
+export { parent } from './parent';

--- a/__test__/case_9/nino.ts
+++ b/__test__/case_9/nino.ts
@@ -1,0 +1,1 @@
+export const hola = () => console.log("¡Hola Mundo!");

--- a/__test__/case_9/parent.ts
+++ b/__test__/case_9/parent.ts
@@ -1,0 +1,6 @@
+import { child, niño } from ".";
+
+export const parent = () => {
+  child();
+  niño();
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "devDependencies": {
         "@swc/core": "^1.3.8",
         "@swc/jest": "^0.2.23",
+        "@types/jest": "^29.2.6",
         "jest": "^29.0.3"
     },
     "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,11 +3,13 @@ lockfileVersion: 5.4
 specifiers:
   '@swc/core': ^1.3.8
   '@swc/jest': ^0.2.23
+  '@types/jest': ^29.2.6
   jest: ^29.0.3
 
 devDependencies:
   '@swc/core': 1.3.8
   '@swc/jest': 0.2.23_@swc+core@1.3.8
+  '@types/jest': 29.2.6
   jest: 29.0.3
 
 packages:
@@ -875,6 +877,13 @@ packages:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
+    dev: true
+
+  /@types/jest/29.2.6:
+    resolution: {integrity: sha512-XEUC/Tgw3uMh6Ho8GkUtQ2lPhY5Fmgyp3TdlkTJs1W9VgNxs+Ow/x3Elh8lHQKqCbZL0AubQuqWjHVT033Hhrw==}
+    dependencies:
+      expect: 29.0.3
+      pretty-format: 29.0.3
     dev: true
 
   /@types/node/18.11.0:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-stable
+nightly-2022-09-23

--- a/src/local_export_strip.rs
+++ b/src/local_export_strip.rs
@@ -281,7 +281,7 @@ impl LocalExportStrip {
                 // ->
                 // import { "x-1" as x1 } from "foo"
                 // export { x1 as "y-1" }
-                let name = &exported.unwrap_or_else(|| orig.clone());
+                let name = exported.as_ref().unwrap_or(&orig);
 
                 let key = key_from_export_name(name);
                 let local = local_ident_from_export_name(orig.clone());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use swc_core::{
         atoms::{js_word, JsWord},
         utils::{
             is_valid_prop_ident, member_expr, private_ident, quote_ident, quote_str, ExprFactory,
-            FunctionFactory,
+            FunctionFactory, IdentExt,
         },
     },
 };
@@ -233,5 +233,22 @@ pub(crate) fn esm_export() -> Function {
         is_async: false,
         type_params: None,
         return_type: None,
+    }
+}
+
+pub(crate) fn key_from_export_name(n: &ModuleExportName) -> (JsWord, Span) {
+    match n {
+        ModuleExportName::Ident(ident) => (ident.sym.clone(), ident.span),
+        ModuleExportName::Str(str) => (str.value.clone(), str.span),
+    }
+}
+
+pub(crate) fn local_ident_from_export_name(n: ModuleExportName) -> Ident {
+    match n {
+        ModuleExportName::Ident(ident) => ident.private(),
+        ModuleExportName::Str(str) => match Ident::verify_symbol(&str.value) {
+            Ok(_) => private_ident!(str.value),
+            Err(s) => private_ident!(s),
+        },
     }
 }

--- a/tests/fixture/case_11/input.js
+++ b/tests/fixture/case_11/input.js
@@ -1,0 +1,9 @@
+import { foo } from "foo";
+export { foo, foofoo } from "foo";
+
+import { bar } from "bar";
+export { "b-a-r" as bar } from "bar";
+
+export { "x-1" as "y-1" } from "baz";
+
+export * as ns from "ns";

--- a/tests/fixture/case_11/output.js
+++ b/tests/fixture/case_11/output.js
@@ -1,0 +1,21 @@
+export { };
+function _export(target, all) {
+    for(var name in all)Object.defineProperty(target, name, {
+        enumerable: true,
+        get: all[name],
+        configurable: true
+    });
+}
+_export(exports, {
+    foo: ()=>foo1,
+    foofoo: ()=>foofoo,
+    bar: ()=>bar1,
+    "y-1": ()=>x1,
+    ns: ()=>ns
+});
+import { foo } from "foo";
+import { foo as foo1, foofoo as foofoo } from "foo";
+import { bar } from "bar";
+import { "b-a-r" as bar1 } from "bar";
+import { "x-1" as x1 } from "baz";
+import * as ns from "ns";


### PR DESCRIPTION
- fix #18
- fix #19 
- fix #20 
- close #21 